### PR TITLE
`username` should be encoded as an URI-Component

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 'use strict';
+
 var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+
 module.exports = function(username, cb) {
   if (typeof username !== 'string') {
     throw new Error('username required');
   }
+  
   var httpGet = function(url) {
     var xmlHttp = new XMLHttpRequest();
     xmlHttp.open('GET', url, false);
@@ -11,8 +14,9 @@ module.exports = function(username, cb) {
     return xmlHttp.responseText;
   };
 
-  var url = 'https://keybase.io/' + username + '/key.asc';
+  var url = 'https://keybase.io/' + encodeURIComponent(username) + '/key.asc';
   var res = httpGet(url);
+  
   if ((res === 'SELF-SIGNED PUBLIC KEY NOT FOUND') || (res.substring(0, 3) === '404')) {
     cb(null);
   } else {


### PR DESCRIPTION
If the `username` contains special characters, like a `/`, the URL could be modified in an unexpected and unintended behaviour.

By using `encodeURIComponent`, characters like `/` get converted to for example `%2F`.